### PR TITLE
Fix NSDecimalString function crashes the Swift compiler issue

### DIFF
--- a/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
+++ b/sources/declarative/encodable/containers/SingleValueEncodingContainer.swift
@@ -191,8 +191,10 @@ extension ShadowEncoder.SingleValueContainer {
     mutating func encode(_ value: Decimal) throws {
         switch self._encoder.sink._withUnsafeGuaranteedRef({ $0.configuration.decimalStrategy }) {
         case .locale(let locale):
-            var number = value
-            let string = NSDecimalString(&number, locale)
+            let nf = NumberFormatter()
+            nf.numberStyle = .decimal
+            nf.locale = locale
+            let string = nf.string(from: NSDecimalNumber(decimal: value))
             try self.encode(string)
         case .custom(let closure):
             try closure(value, self._encoder)


### PR DESCRIPTION
## Description

There is a known issue happening on Xcode 16 beta 6, that prevents us from compiling the project. ([link](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes)).

> If meeting both of the following scenarios, your app may crash on launch on platforms earlier than the latest versions of the respective OS with errors indicating missing symbols in NSDecimal:

I found that, it's from this repo: [CodableCSV](https://github.com/dehesa/CodableCSV)

One problem is, the repo was stopped supporting 3 years ago, then it should be no hope for it to be updated. One solution is, we folk that repos to our bloom repos, and keep maintaining it, and use it from the main DayOne-Apple project.

So, this PR is to fix that issue.

Note that, Apple has already acknowledged the issue, then this PR is just an ad-hoc solution.  This PR _might be_ reverted when the new Xcode version is released.

## Checklist

The following list must only be fulfilled by code-changing PRs. If you are making changes on the documentation, ignore these.

-   [ ] Include in-code documentation at the top of the property/function/structure/class (if necessary).
-   [ ] Add to existing tests or create new tests (if necessary).
-  [x] The module can be built successfully on Xcode 16 beta 6 and above.
